### PR TITLE
fix: Renamed Cloudtrail class name 

### DIFF
--- a/src/services/cloudtrail/index.ts
+++ b/src/services/cloudtrail/index.ts
@@ -1,16 +1,16 @@
-import { Service } from '@cloudgraph/sdk';
-import BaseService from '../base';
-import format from './format';
-import getData from './data';
+import { Service } from '@cloudgraph/sdk'
+import BaseService from '../base'
+import format from './format'
+import getData from './data'
 import getConnections from './connections'
-import mutation from './mutation';
+import mutation from './mutation'
 
-export default class AwsAsg extends BaseService implements Service {
-  format = format.bind(this);
+export default class Cloudtrail extends BaseService implements Service {
+  format = format.bind(this)
 
-  getData = getData.bind(this);
+  getData = getData.bind(this)
 
   getConnections = getConnections.bind(this)
 
-  mutation = mutation;
+  mutation = mutation
 }


### PR DESCRIPTION
## Changes/solution

- Renamed Cloudtrail class name.
