### PR TITLE
fix(arn): Added ARN to some existing services

### DIFF
--- a/src/services/flowLogs/format.ts
+++ b/src/services/flowLogs/format.ts
@@ -1,5 +1,6 @@
 import { AwsFlowLog } from '../../types/generated'
 import { formatTagsFromMap } from '../../utils/format'
+import { flowLogsArn } from '../../utils/generateArns'
 import { RawFlowLog } from './data'
 
 /**
@@ -37,6 +38,11 @@ export default ({
 
   const flowLog = {
     id,
+    arn: flowLogsArn({
+      region,
+      account,
+      flowLogId: id,
+    }),
     region,
     accountId: account,
     deliverLogsErrorMessage,

--- a/src/services/guardDutyDetector/format.ts
+++ b/src/services/guardDutyDetector/format.ts
@@ -2,6 +2,7 @@ import cuid from 'cuid'
 import { formatTagsFromMap } from '../../utils/format'
 import { AwsGuardDutyDetector } from '../../types/generated'
 import { RawAwsGuardDutyDetector } from './data'
+import { guardDutyArn } from '../../utils/generateArns'
 
 /**
  * GuardDutyDetector
@@ -25,21 +26,21 @@ export default ({
     UpdatedAt: updatedAt,
     DataSources: dataSources,
     members = [],
-    Tags
+    Tags,
   } = rawData
 
   const formattedDataSources = {
     cloudTrail: {
-      status: dataSources?.CloudTrail?.Status
+      status: dataSources?.CloudTrail?.Status,
     },
     dnsLogs: {
-      status: dataSources?.DNSLogs?.Status
+      status: dataSources?.DNSLogs?.Status,
     },
     flowLogs: {
-      status: dataSources?.FlowLogs?.Status
+      status: dataSources?.FlowLogs?.Status,
     },
     s3Logs: {
-      status: dataSources?.S3Logs?.Status
+      status: dataSources?.S3Logs?.Status,
     },
     // kubernetes: { TODO: k8s logs support, maybe need to update aws sdk?
     //   auditLogs: {
@@ -56,11 +57,12 @@ export default ({
     email: member?.Email,
     relationshipStatus: member?.RelationshipStatus,
     invitedAt: new Date(member?.InvitedAt)?.toISOString(),
-    updatedAt: new Date(member?.UpdatedAt)?.toISOString()
+    updatedAt: new Date(member?.UpdatedAt)?.toISOString(),
   }))
 
   return {
     id,
+    arn: guardDutyArn({ region, account, detectorId: id }),
     region,
     accountId: account,
     createdAt: new Date(createdAt)?.toISOString(),
@@ -70,6 +72,6 @@ export default ({
     status,
     members: mappedMembers,
     dataSources: formattedDataSources,
-    tags: formatTagsFromMap(Tags ?? {})
+    tags: formatTagsFromMap(Tags ?? {}),
   }
 }

--- a/src/utils/generateArns.ts
+++ b/src/utils/generateArns.ts
@@ -284,3 +284,13 @@ export const flowLogsArn = ({
   account: string
   flowLogId: string
 }): string => `arn:aws:ec2:${region}:${account}:vpc-flow-log/${flowLogId}`
+
+export const guardDutyArn = ({
+  region,
+  account,
+  detectorId,
+}: {
+  region: string
+  account: string
+  detectorId: string
+}): string => `arn:aws:guardduty:${region}:${account}:detector/${detectorId}`

--- a/src/utils/generateArns.ts
+++ b/src/utils/generateArns.ts
@@ -9,6 +9,7 @@ export const apiGatewayMethodArn = ({ resourceArn, httpMethod }) =>
   `${resourceArn}/methods/${httpMethod}`
 export const route53HostedZoneArn = ({ id }: { id: string }): string =>
   `arn:aws:route53:::hostedzone/${id}`
+
 export const routeTableArn = ({
   region,
   account,
@@ -69,7 +70,7 @@ export const kmsArn = ({
   region: string
   account: string
   id: string
-}) : string => `arn:aws:kms:${region}:${account}:key/${id}`
+}): string => `arn:aws:kms:${region}:${account}:key/${id}`
 
 export const ecsContainerArn = ({
   region,
@@ -105,7 +106,7 @@ export const ebsVolumeArn = ({
   region,
   account,
   id,
-} : {
+}: {
   region: string
   account: string
   id: string
@@ -115,7 +116,7 @@ export const ec2InstanceArn = ({
   region,
   account,
   id,
-} : {
+}: {
   region: string
   account: string
   id: string
@@ -125,7 +126,7 @@ export const eipAllocationArn = ({
   region,
   account,
   id,
-} : {
+}: {
   region: string
   account: string
   id: string
@@ -135,17 +136,18 @@ export const elbArn = ({
   region,
   account,
   name,
-} : {
+}: {
   region: string
   account: string
   name: string
-}): string => `arn:aws:elasticloadbalancing:${region}:${account}:loadbalancer/${name}`
+}): string =>
+  `arn:aws:elasticloadbalancing:${region}:${account}:loadbalancer/${name}`
 
 export const igwArn = ({
   region,
   account,
   id,
-} : {
+}: {
   region: string
   account: string
   id: string
@@ -155,7 +157,7 @@ export const networkInterfaceArn = ({
   region,
   account,
   id,
-} : {
+}: {
   region: string
   account: string
   id: string
@@ -165,7 +167,7 @@ export const securityGroupArn = ({
   region,
   account,
   id,
-} : {
+}: {
   region: string
   account: string
   id: string
@@ -175,7 +177,7 @@ export const vpcArn = ({
   region,
   account,
   id,
-} : {
+}: {
   region: string
   account: string
   id: string
@@ -185,7 +187,7 @@ export const clientVpnEndpointArn = ({
   region,
   account,
   id,
-} : {
+}: {
   region: string
   account: string
   id: string
@@ -195,7 +197,7 @@ export const vpnConnectionArn = ({
   region,
   account,
   id,
-} : {
+}: {
   region: string
   account: string
   id: string
@@ -205,11 +207,12 @@ export const transitGatewayAttachmentArn = ({
   region,
   account,
   id,
-} : {
+}: {
   region: string
   account: string
   id: string
-}): string => `arn:aws:ec2:${region}:${account}:transit-gateway-attachment/${id}`
+}): string =>
+  `arn:aws:ec2:${region}:${account}:transit-gateway-attachment/${id}`
 
 export const configurationRecorderArn = ({
   region,
@@ -224,7 +227,7 @@ export const configurationRecorderArn = ({
 export const athenaDataCatalogArn = ({
   region,
   account,
-  name
+  name,
 }: {
   region: string
   account: string
@@ -234,7 +237,7 @@ export const athenaDataCatalogArn = ({
 export const glueJobArn = ({
   region,
   account,
-  name
+  name,
 }: {
   region: string
   account: string
@@ -244,7 +247,7 @@ export const glueJobArn = ({
 export const ssmManagedInstanceArn = ({
   region,
   account,
-  name
+  name,
 }: {
   region: string
   account: string
@@ -254,7 +257,7 @@ export const ssmManagedInstanceArn = ({
 export const ssmDocumentArn = ({
   region,
   account,
-  name
+  name,
 }: {
   region: string
   account: string
@@ -269,4 +272,15 @@ export const cognitoIdentityPoolArn = ({
   region: string
   account: string
   identityPoolId: string
-}): string => `arn:aws:cognito-identity:${region}:${account}:identitypool/${identityPoolId}`
+}): string =>
+  `arn:aws:cognito-identity:${region}:${account}:identitypool/${identityPoolId}`
+
+export const flowLogsArn = ({
+  region,
+  account,
+  flowLogId,
+}: {
+  region: string
+  account: string
+  flowLogId: string
+}): string => `arn:aws:ec2:${region}:${account}:vpc-flow-log/${flowLogId}`


### PR DESCRIPTION
## Issue tracker links

[CG-1079](https://autoclouddev.atlassian.net/browse/CG-1079)

## Changes/solution

- Generated ARN for flowLogs service.
- Generated ARN for guardDuty service.

Here's the list of services with an ARN:

- clientVpnEndpoint ✅
- cognitoIdentityPool ✅
- ecsTaskSet ✅
- efsMountTarget 🚫
- elastiCacheReplicationGroup ✅
- elasticSearchDomain ✅
- flowLog ✅
- guardDutyDetector ✅
- emrCluster ✅
- emrInstance 🚫
- emrStep 🚫
- route53Record 🚫

Derived services don't have ARNs or Tags because they were created for CG. The alternative could be to deconvert them and remove them as top-level services or keep them but add a synthetic ARN based on his father.


