### PR TITLE
chore(services): reduce memory usage

### DIFF
--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -786,10 +786,7 @@ export default class Provider extends CloudGraph.Client {
                     connections
                   )
                 }
-                result.connections = {
-                  ...result.connections,
-                  ...serviceConnections,
-                }
+                Object.assign(result.connections, serviceConnections)
               }
             })
           }


### PR DESCRIPTION
By mutating the result directly we avoid repeatedly copying the same elements on every iteration. When there are a few thousand connections, that means cloning such array a few thousand times (moving millions of elements!).

This doesn't drastically improve performance, but it does make the GC much happier.