### PR TITLE
small fixes for cloud9 and dynamodb

### DIFF
--- a/src/services/cloud9/data.ts
+++ b/src/services/cloud9/data.ts
@@ -28,8 +28,8 @@ const errorLog = new AwsErrorLog(serviceName)
 const endpoint = initTestEndpoint(serviceName)
 const MAX_ITEMS = 25
 
-const listEnvironmentsForRegion = async ({ 
-  cloud9, 
+const listEnvironmentsForRegion = async ({
+  cloud9,
   resolveRegion,
 }: {
   cloud9: Cloud9
@@ -150,7 +150,7 @@ export default async ({
   [region: string]: RawAwsCloud9Environment[]
 }> =>
   new Promise(async resolve => {
-    const cloud9Data: RawAwsCloud9Environment[] = []
+    let cloud9Data: RawAwsCloud9Environment[] = []
     const environmentPromises = []
     const regionPromises = []
     const tagsPromises = []
@@ -208,6 +208,8 @@ export default async ({
     logger.debug(lt.gettingCloud9Environments)
     await Promise.all(environmentPromises)
 
+    // remove environments that don't have an arn (failed to get attributes)
+    cloud9Data = cloud9Data.filter(({ arn }) => !!arn)
     // get all tags for each environment
     cloud9Data.map(({ arn, region }, idx) => {
       const cloud9 = new Cloud9({ ...config, region, endpoint })

--- a/src/services/dynamodb/data.ts
+++ b/src/services/dynamodb/data.ts
@@ -49,7 +49,7 @@ export interface RawAwsDynamoDbTable
 }
 
 const checkIfEnabled = (status: string): boolean =>
-  status && !['DISABLED', 'DISABLING'].includes(status)
+  !!status && !['DISABLED', 'DISABLING'].includes(status)
 
 const ttlInfoFormatter = (ttlInfo: TimeToLiveDescription): boolean => {
   const { TimeToLiveStatus } = ttlInfo
@@ -59,10 +59,9 @@ const ttlInfoFormatter = (ttlInfo: TimeToLiveDescription): boolean => {
 const backupInfoFormatter = (
   backupInfo: ContinuousBackupsDescription
 ): boolean => {
-  const {
-    PointInTimeRecoveryDescription: { PointInTimeRecoveryStatus },
-  } = backupInfo
-  return checkIfEnabled(PointInTimeRecoveryStatus)
+  const status =
+    backupInfo?.PointInTimeRecoveryDescription?.PointInTimeRecoveryStatus
+  return checkIfEnabled(status)
 }
 
 /**
@@ -345,8 +344,7 @@ export default async ({
     tableData.map(({ TableName, region }, idx) => {
       const dynamoDb = new DynamoDB({ ...config, region, endpoint })
       const backupInfoPromise = new Promise<void>(async resolveBackupInfo => {
-        const backupInfo: ContinuousBackupsDescription =
-          await getTableBackupsDescription(dynamoDb, TableName)
+        const backupInfo = await getTableBackupsDescription(dynamoDb, TableName)
         tableData[idx].pointInTimeRecoveryEnabled =
           backupInfoFormatter(backupInfo)
         resolveBackupInfo()


### PR DESCRIPTION
cloud9 data uses 'getEnvironmentAttributes' which returns empty when an error occurs (fine). But then the cloud9 instance moves forward with an invalid state.


dynamodb: backupInfo.PointInTimeRecoveryDescription?.PointInTimeRecoveryStatus is optional in aws interface. so we crash when that happens.