### PR TITLE
Detect and scan all active (opted-in) regions if no region list is provided

### DIFF
--- a/src/services/base/index.ts
+++ b/src/services/base/index.ts
@@ -14,6 +14,12 @@ export interface rawDataInterface {
   accountId?: string
   data: any
 }
+
+export interface rawDataResponseInterface {
+  rawData: rawDataInterface[]
+  regions: string[]
+}
+
 export default class BaseService {
   constructor(config: any) {
     this.logger = config.logger


### PR DESCRIPTION
## Changes/solution

There are multiple regions in AWS that are opt in and not enabled by default. Attempting to scan these regions just slows things down. This adds an active region check which runs when no region list is provided. This also updates the init script to not create an entry at all for 'regions' in the config file if the user doesn't select any regions (which causes the region detection code to run).

## Testing

I have run this locally against a test account after removing the region configuration from my config file and can verify that non-opted-in regions were not scanned.

## Notes and considerations

After these changes it didn't really make sense to setup the regions at the global level, so I moved them to a per-account level.

There is one completely different approach I could've taken here, I could've made this code automatically filter out any regions that the user may have enabled that are not opted into. If desired I can update these changes to use that approach instead.

## Dependencies

N/A
